### PR TITLE
Supporting missing NullType fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ env: PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR/avro_validator
 install:
   "pip install -r requirements.txt"
 script:
-  pytest avro_validator/tests --cov=avro_validator
+  pytest avro_validator/tests --cov=avro_validator && flake8 avro_validator
 after_success:
   coveralls

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/leocalm/avro_validator.svg?branch=master)](https://travis-ci.org/leocalm/avro_validator)
 [![Coverage Status](https://coveralls.io/repos/github/leocalm/avro_validator/badge.svg?branch=master)](https://coveralls.io/github/leocalm/avro_validator?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/avro-validator/badge/?version=latest)](https://avro-validator.readthedocs.io/en/latest/?badge=latest)
-
+[![PyPI version](https://badge.fury.io/py/avro-validator.svg)](https://badge.fury.io/py/avro-validator)
 
 # Avro Validator
 A pure python avro schema validator.

--- a/avro_validator/avro_types.py
+++ b/avro_validator/avro_types.py
@@ -561,8 +561,8 @@ class RecordType(ComplexType):
 
         valueks = set(value.keys())
         reqdflds = set([x for x in self.__fields.keys() 
-                        if not (self.__fields[x].isInstance(NullType) 
-                            or (self.__fields[x].isInstance(UnionType) and NullType in [type(y) for y in self.__fields[x].type.types]))])
+                        if not (self.__fields[x].isinstance(NullType) 
+                            or (self.__fields[x].isinstance(UnionType) and NullType in [type(y) for y in self.__fields[x].type.types]))])
 
         if not reqdflds.issubset(valueks):
             missingfields = reqdflds - valueks

--- a/avro_validator/avro_types.py
+++ b/avro_validator/avro_types.py
@@ -559,9 +559,14 @@ class RecordType(ComplexType):
         if not self.check_type(value):
             raise ValueError(f'The value [{value}] should have type dict but it has [{type(value)}].')
 
-        if set(value.keys()) != self.__fields.keys():
-            raise ValueError(f'The fields from value [{value}] differs from the fields '
-                             f'of the record type [{self.__fields}]')
+        valueks = set(value.keys())
+        reqdflds = set([x for x in self.__fields.keys() if not (NullType == type(self.__fields[x].type) or (UnionType == type(self.__fields[x].type) and NullType in [type(y) for y in self.__fields[x].type.types]))])
+        
+        if not reqdflds.issubset(valueks):
+            missingfields = reqdflds - valueks
+            raise ValueError(f'The fields from value [{valueks}] differs from the fields '
+                             f'of the record type [{reqdflds}].  The following fields are '
+                             f'required, but not present: [{missingfields}].')
 
         for key, field_value in value.items():
             self._validate_field(key, field_value)

--- a/avro_validator/avro_types.py
+++ b/avro_validator/avro_types.py
@@ -560,8 +560,10 @@ class RecordType(ComplexType):
             raise ValueError(f'The value [{value}] should have type dict but it has [{type(value)}].')
 
         valueks = set(value.keys())
-        reqdflds = set([x for x in self.__fields.keys() if not (NullType == type(self.__fields[x].type) or (UnionType == type(self.__fields[x].type) and NullType in [type(y) for y in self.__fields[x].type.types]))])
-        
+        reqdflds = set([x for x in self.__fields.keys() 
+                        if not (self.__fields[x].isInstance(NullType) 
+                            or (self.__fields[x].isInstance(UnionType) and NullType in [type(y) for y in self.__fields[x].type.types]))])
+
         if not reqdflds.issubset(valueks):
             missingfields = reqdflds - valueks
             raise ValueError(f'The fields from value [{valueks}] differs from the fields '

--- a/avro_validator/avro_types.py
+++ b/avro_validator/avro_types.py
@@ -568,6 +568,12 @@ class RecordType(ComplexType):
                              f'of the record type [{reqdflds}].  The following fields are '
                              f'required, but not present: [{missingfields}].')
 
+        if not valueks.issubset(set(self.__fields.keys())):
+            extrafields = set(self.__fields.keys()) - valueks
+            raise ValueError(f'The fields from value [{valueks}] differs from the fields '
+                             f'of the record type [{reqdflds}].  The following fields are '
+                             f'not in the schema, but are present: [{extrafields}].')
+
         for key, field_value in value.items():
             self._validate_field(key, field_value)
 

--- a/avro_validator/avro_types.py
+++ b/avro_validator/avro_types.py
@@ -560,9 +560,12 @@ class RecordType(ComplexType):
             raise ValueError(f'The value [{value}] should have type dict but it has [{type(value)}].')
 
         valueks = set(value.keys())
-        reqdflds = set([x for x in self.__fields.keys() 
-                        if not (self.__fields[x].isinstance(NullType) 
-                            or (self.__fields[x].isinstance(UnionType) and NullType in [type(y) for y in self.__fields[x].type.types]))])
+        reqdflds = set([x for x in self.__fields.keys()
+                        if not (isinstance(self.__fields[x].type, NullType)
+                                or (isinstance(self.__fields[x].type, UnionType)
+                                    and NullType in [type(y) for y in self.__fields[x].type.types])
+                                )
+                        ])
 
         if not reqdflds.issubset(valueks):
             missingfields = reqdflds - valueks

--- a/avro_validator/tests/test_avro_validator.py
+++ b/avro_validator/tests/test_avro_validator.py
@@ -285,6 +285,11 @@ def test_record_type(value):
     assert RecordType({'name': RecordTypeField('name', StringType())}).validate(value) is True
 
 
+@given(value=fixed_dictionaries({'name': text()}))
+def test_record_type_repr(value):
+    assert str(RecordType({'name': RecordTypeField('name', StringType())})) == "RecordType <{'name': RecordTypeField <name: name, type: StringType, doc: None, default: None, order: None, aliases: None>}>"
+
+
 @given(value=one_of(integers(),
                     none(),
                     lists(elements=integers()),
@@ -311,9 +316,19 @@ def test_record_type_invalid_value_type(value):
 
 @given(value=fixed_dictionaries({'name': text(), 'age': integers()}))
 def test_record_type_additional_key_in_value(value):
-    regex = r'The fields from value \[.*\] differs from the fields of the record type \[.*\]'
+    regex = r"The fields from value \[.*\] differs from the fields of the record type \[.*\].  The following fields are not in the schema, but are present: \[.*\]."
     with pytest.raises(ValueError, match=regex):
         RecordType({'name': RecordTypeField('name', StringType())}).validate(value)
+
+
+@given(value=fixed_dictionaries({'name': text(), 'age': integers(max_value=200)}))
+def test_record_type_optional_key_in_value(value):
+    assert RecordType({'name': RecordTypeField('name', StringType()), 'age': RecordTypeField('age', UnionType([NullType(), IntType()]))}).validate(value) is True
+
+
+@given(value=fixed_dictionaries({'name': text()}))
+def test_record_type_optional_key_not_in_value(value):
+    assert RecordType({'name': RecordTypeField('name', StringType()), 'age': RecordTypeField('age', UnionType([NullType(), IntType()]))}).validate(value) is True
 
 
 @given(value=fixed_dictionaries({'name': text()}))

--- a/avro_validator/tests/test_avro_validator.py
+++ b/avro_validator/tests/test_avro_validator.py
@@ -287,7 +287,9 @@ def test_record_type(value):
 
 @given(value=fixed_dictionaries({'name': text()}))
 def test_record_type_repr(value):
-    assert str(RecordType({'name': RecordTypeField('name', StringType())})) == "RecordType <{'name': RecordTypeField <name: name, type: StringType, doc: None, default: None, order: None, aliases: None>}>"
+    msg = "RecordType <{'name': RecordTypeField <name: name, type: StringType, " \
+          "doc: None, default: None, order: None, aliases: None>}>"
+    assert str(RecordType({'name': RecordTypeField('name', StringType())})) == msg
 
 
 @given(value=one_of(integers(),
@@ -316,19 +318,28 @@ def test_record_type_invalid_value_type(value):
 
 @given(value=fixed_dictionaries({'name': text(), 'age': integers()}))
 def test_record_type_additional_key_in_value(value):
-    regex = r"The fields from value \[.*\] differs from the fields of the record type \[.*\].  The following fields are not in the schema, but are present: \[.*\]."
+    regex = r"The fields from value \[.*\] differs from the fields of the record type \[.*\].  " \
+            r"The following fields are not in the schema, but are present: \[.*\]."
     with pytest.raises(ValueError, match=regex):
         RecordType({'name': RecordTypeField('name', StringType())}).validate(value)
 
 
 @given(value=fixed_dictionaries({'name': text(), 'age': integers(max_value=200)}))
 def test_record_type_optional_key_in_value(value):
-    assert RecordType({'name': RecordTypeField('name', StringType()), 'age': RecordTypeField('age', UnionType([NullType(), IntType()]))}).validate(value) is True
+    assert RecordType(
+            {'name': RecordTypeField('name', StringType()),
+             'age': RecordTypeField('age', UnionType([NullType(), IntType()]))
+             }
+          ).validate(value) is True
 
 
 @given(value=fixed_dictionaries({'name': text()}))
 def test_record_type_optional_key_not_in_value(value):
-    assert RecordType({'name': RecordTypeField('name', StringType()), 'age': RecordTypeField('age', UnionType([NullType(), IntType()]))}).validate(value) is True
+    assert RecordType(
+            {'name': RecordTypeField('name', StringType()),
+             'age': RecordTypeField('age', UnionType([NullType(), IntType()]))
+             }
+          ).validate(value) is True
 
 
 @given(value=fixed_dictionaries({'name': text()}))

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@ testpaths = avro_validator/tests
 
 [flake8]
 per-file-ignores = avro_validator/__init__.py:F401
+max-line-length = 120
+exclude = tests/*
+max-complexity = 10
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
If a field is NullType or is a UnionType with one of the options being a NullType field, this allow pass the schema if the field is missing.